### PR TITLE
feat: add total expenses summary bar to main page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import ExpenseForm from "@/components/ExpenseForm";
 import ExpenseList from "@/components/ExpenseList";
+import SummaryBar from "@/components/SummaryBar";
 import { Expense } from "@/lib/types";
 
 export default function Home() {
@@ -25,6 +26,7 @@ export default function Home() {
     <main className="max-w-2xl mx-auto py-10 px-4 flex flex-col gap-6">
       <h1 className="text-3xl font-bold">Expense Tracker</h1>
       <ExpenseForm onAdd={handleAdd} />
+      <SummaryBar expenses={expenses} />
       <ExpenseList expenses={expenses} onDelete={handleDelete} />
     </main>
   );

--- a/components/SummaryBar.tsx
+++ b/components/SummaryBar.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { Expense } from "@/lib/types";
+
+interface SummaryBarProps {
+  expenses: Expense[];
+}
+
+export default function SummaryBar({ expenses }: SummaryBarProps) {
+  const totalCount = expenses.length;
+  const totalAmount = expenses.reduce((sum, e) => sum + e.amount, 0);
+
+  const categoryTotals = expenses.reduce<Record<string, number>>((acc, e) => {
+    acc[e.category] = (acc[e.category] || 0) + e.amount;
+    return acc;
+  }, {});
+
+  if (totalCount === 0) return null;
+
+  return (
+    <div className="bg-gray-100 rounded-lg p-4 flex flex-col gap-2">
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-gray-600">
+          {totalCount} expense{totalCount !== 1 ? "s" : ""}
+        </span>
+        <span className="text-lg font-bold">${totalAmount.toFixed(2)}</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {Object.entries(categoryTotals)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([category, amount]) => (
+            <span
+              key={category}
+              className="text-xs bg-white rounded px-2 py-1 text-gray-700"
+            >
+              {category}: ${amount.toFixed(2)}
+            </span>
+          ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Created `components/SummaryBar.tsx` component that displays total expense count, total amount spent (formatted as currency), and a per-category breakdown
- Integrated the summary bar into `app/page.tsx`, positioned above the expense list
- The summary bar hides when there are no expenses

Closes #3

## Test plan
- [x] `next build` passes
- [x] All existing tests pass
- [ ] Verify summary bar appears with correct totals when expenses exist
- [ ] Verify summary bar hides when no expenses are present
- [ ] Verify category breakdown updates correctly when adding/deleting expenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)